### PR TITLE
refactoring main.go to have only one instance of the database

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,25 +1,46 @@
 package main
 
 import (
+	"log"
+	"os"
+
+	customerModel "github.com/chronicler-org/core/src/customer/model"
 	customerRouter "github.com/chronicler-org/core/src/customer/router"
+	managerModel "github.com/chronicler-org/core/src/manager/model"
 	managerRouter "github.com/chronicler-org/core/src/manager/router"
+	tagModel "github.com/chronicler-org/core/src/tag/model"
 	tagRouter "github.com/chronicler-org/core/src/tag/router"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/logger"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
 )
 
 func main() {
+	// inicializa o banco de dados
+	dbURL := os.Getenv("DATABASE_URL")
+	db, err := gorm.Open(postgres.Open(dbURL))
+	if err != nil {
+		log.Fatal(err)
+	}
+	// realiza migration das entidades no banco de dados
+	db.AutoMigrate(&managerModel.Manager{}, &customerModel.Customer{}, &tagModel.Tag{})
+
+	// inicializa app principal
 	app := fiber.New()
 
+	// instancia logger que permite visualizacao das rotas acessadas e status codes retornados
 	app.Use(logger.New())
 
+	// rota raiz
 	app.Get("/", func(c *fiber.Ctx) error {
 		return c.SendString("Hello, World!")
 	})
 
-	app.Mount("/manager", managerRouter.NewManagerRouter())
-	app.Mount("/customer", customerRouter.NewCustomerRouter())
-	app.Mount("/tag", tagRouter.NewTagRouter())
+	// instancia as rotas para cada entidade
+	managerRouter.InitManagerRouter(app, db)
+	customerRouter.InitCustomerRouter(app, db)
+	tagRouter.InitTagRouter(app, db)
 
 	app.Listen(":8080")
 }

--- a/src/customer/repository/repository.go
+++ b/src/customer/repository/repository.go
@@ -1,11 +1,7 @@
 package customerRepository
 
 import (
-	"os"
-
 	customerModel "github.com/chronicler-org/core/src/customer/model"
-	"github.com/gofiber/fiber/v2/log"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
 
@@ -13,20 +9,9 @@ type CustomerRepository struct {
 	db *gorm.DB
 }
 
-func initDB() *gorm.DB {
-	dbURL := os.Getenv("DATABASE_URL")
-	db, err := gorm.Open(postgres.Open(dbURL), &gorm.Config{})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	db.AutoMigrate(&customerModel.Customer{})
-	return db
-}
-
-func InitCustomerRepository() *CustomerRepository {
+func InitCustomerRepository(db *gorm.DB) *CustomerRepository {
 	return &CustomerRepository{
-		db: initDB(),
+		db: db,
 	}
 }
 

--- a/src/customer/router/router.go
+++ b/src/customer/router/router.go
@@ -5,20 +5,17 @@ import (
 	customerRepository "github.com/chronicler-org/core/src/customer/repository"
 	customerService "github.com/chronicler-org/core/src/customer/service"
 	"github.com/gofiber/fiber/v2"
+	"gorm.io/gorm"
 )
 
-func NewCustomerRouter() *fiber.App {
-	router := fiber.New()
-
-	repository := customerRepository.InitCustomerRepository()
+func InitCustomerRouter(router *fiber.App, db *gorm.DB) {
+	repository := customerRepository.InitCustomerRepository(db)
 	service := customerService.InitCustomerService(repository)
 	controller := customerController.InitCustomerController(service)
 
-	router.Get("/", controller.HandleFindAll)
-	router.Get(":id", controller.HandleFindByID)
-	router.Post("/", controller.HandleCreateCustomer)
-	router.Patch(":id", controller.HandleUpdateCustomer)
-	router.Delete(":id", controller.HandleDeleteCustomer)
-
-	return router
+	router.Get("/customer", controller.HandleFindAll)
+	router.Get("/customer/:id", controller.HandleFindByID)
+	router.Post("/customer", controller.HandleCreateCustomer)
+	router.Patch("/customer/:id", controller.HandleUpdateCustomer)
+	router.Delete("/customer/:id", controller.HandleDeleteCustomer)
 }

--- a/src/manager/repository/repository.go
+++ b/src/manager/repository/repository.go
@@ -1,11 +1,7 @@
 package managerRepository
 
 import (
-	"os"
-
 	managerModel "github.com/chronicler-org/core/src/manager/model"
-	"github.com/gofiber/fiber/v2/log"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
 
@@ -13,20 +9,9 @@ type ManagerRepository struct {
 	db *gorm.DB
 }
 
-func initDB() *gorm.DB {
-	dbURL := os.Getenv("DATABASE_URL")
-	db, err := gorm.Open(postgres.Open(dbURL), &gorm.Config{})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	db.AutoMigrate(&managerModel.Manager{})
-	return db
-}
-
-func InitManagerRepository() *ManagerRepository {
+func InitManagerRepository(db *gorm.DB) *ManagerRepository {
 	return &ManagerRepository{
-		db: initDB(),
+		db: db,
 	}
 }
 

--- a/src/manager/router/router.go
+++ b/src/manager/router/router.go
@@ -6,22 +6,20 @@ import (
 	"github.com/chronicler-org/core/src/manager/service"
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
+	"gorm.io/gorm"
 )
 
-func NewManagerRouter() *fiber.App {
+func InitManagerRouter(router *fiber.App, db *gorm.DB) {
 
-	router := fiber.New()
-
-	repository := managerRepository.InitManagerRepository()
+	repository := managerRepository.InitManagerRepository(db)
 	validate := validator.New()
 	service := managerService.InitManagerService(repository, validate)
 	controller := managerController.InitManagerController(service)
 
-	router.Get("/", controller.HandleFindAll)
-	router.Get(":id", controller.HandleFindByID)
-	router.Post("/", controller.HandleCreateManager)
-	router.Patch(":id", controller.HandleUpdateManager)
-	router.Delete(":id", controller.HandleDeleteManager)
+	router.Get("/manager", controller.HandleFindAll)
+	router.Get("/manager/:id", controller.HandleFindByID)
+	router.Post("/manager", controller.HandleCreateManager)
+	router.Patch("/manager/:id", controller.HandleUpdateManager)
+	router.Delete("/manager/:id", controller.HandleDeleteManager)
 
-	return router
 }

--- a/src/manager/service/service.go
+++ b/src/manager/service/service.go
@@ -80,8 +80,9 @@ func (service *ManagerService) Update(id string, dto managerDTO.UpdateManagerDTO
 	if dto.Email != "" {
 		if dto.ValidateEmail() {
 			updatedManager.Email = dto.Email
+		} else {
+			return updatedManager, serviceErrors.NewError("novo email é Email invalido")
 		}
-		return updatedManager, serviceErrors.NewError("novo email é Email invalido")
 	}
 	if dto.Password != "" {
 		newPassword, err := bcrypt.GenerateFromPassword([]byte(dto.CPF), 10)

--- a/src/tag/repository/repository.go
+++ b/src/tag/repository/repository.go
@@ -1,11 +1,7 @@
 package tagRepository
 
 import (
-	"log"
-	"os"
-
 	tagModel "github.com/chronicler-org/core/src/tag/model"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
 
@@ -13,20 +9,9 @@ type TagRepository struct {
 	db *gorm.DB
 }
 
-func initDB() *gorm.DB {
-	dbURL := os.Getenv("DATABASE_URL")
-	db, err := gorm.Open(postgres.Open(dbURL), &gorm.Config{})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	db.AutoMigrate(&tagModel.Tag{})
-	return db
-}
-
-func InitTagRepository() *TagRepository {
+func InitTagRepository(db *gorm.DB) *TagRepository {
 	return &TagRepository{
-		db: initDB(),
+		db: db,
 	}
 }
 

--- a/src/tag/router/router.go
+++ b/src/tag/router/router.go
@@ -5,20 +5,17 @@ import (
 	tagRepository "github.com/chronicler-org/core/src/tag/repository"
 	tagService "github.com/chronicler-org/core/src/tag/service"
 	"github.com/gofiber/fiber/v2"
+	"gorm.io/gorm"
 )
 
-func NewTagRouter() *fiber.App {
-	router := fiber.New()
-
-	repository := tagRepository.InitTagRepository()
+func InitTagRouter(router *fiber.App, db *gorm.DB) {
+	repository := tagRepository.InitTagRepository(db)
 	service := tagService.InitTagService(repository)
 	controller := tagController.InitTagController(service)
 
-	router.Get("/", controller.HandleFindAll)
-	router.Get(":id", controller.HandleFindByID)
-	router.Post("/", controller.HandleCreateTag)
-	router.Patch("/:id", controller.HandleUpdateTag)
-	router.Delete("/:id", controller.HandleDeleteTag)
-
-	return router
+	router.Get("/tag", controller.HandleFindAll)
+	router.Get("/tag/:id", controller.HandleFindByID)
+	router.Post("/tag", controller.HandleCreateTag)
+	router.Patch("/tag/:id", controller.HandleUpdateTag)
+	router.Delete("/tag/:id", controller.HandleDeleteTag)
 }


### PR DESCRIPTION
Na versão anterior do código estavamos inicializando uma instancia da conexão ao banco de dados em cada módulo, nos forçando a repetir código em todos os arquivos, com essas alterações nós iremos instanciar apenas uma conexão ao banco de dados e usaremos a mesma em todos os módulos subsequentes. 