### PR TITLE
Add base query with pagination and limit

### DIFF
--- a/src/app/dto/metaDTO.go
+++ b/src/app/dto/metaDTO.go
@@ -4,6 +4,6 @@ type MetaDTO struct {
 	Count      int `json:"count"`
 	Page       int `json:"page"`
 	TotalPages int `json:"total_pages"`
-	TotalCount int `json:"total_count"`
+	TotalCount int64 `json:"total_count"`
 	Limit      int `json:"limit"`
 }

--- a/src/app/dto/paginationDTO.go
+++ b/src/app/dto/paginationDTO.go
@@ -1,0 +1,20 @@
+package appDto
+
+type PaginationDTO struct {
+	Limit int `validate:"omitempty,min=1,max=100" query:"limit" `
+	Page  int `validate:"omitempty,min=1" query:"page" `
+}
+
+func (p *PaginationDTO) GetLimit() int {
+	if p.Limit <= 0 {
+		return 10
+	}
+	return p.Limit
+}
+
+func (p *PaginationDTO) GetPage() int {
+	if p.Page <= 0 {
+		return 1
+	}
+	return p.Page
+}

--- a/src/app/utils/paginateUtil.go
+++ b/src/app/utils/paginateUtil.go
@@ -2,6 +2,7 @@ package appUtil
 
 import (
 	"math"
+	"reflect"
 
 	appDto "github.com/chronicler-org/core/src/app/dto"
 )
@@ -11,9 +12,12 @@ type PaginateResponse struct {
 	Result interface{}    `json:"result"`
 }
 
-func Paginate(data []interface{}, page int, totalCount int, limit int) PaginateResponse {
+func Paginate(data interface{}, totalCount int64, page int, limit int) PaginateResponse {
+	dataSlice := reflect.ValueOf(data)
+	count := dataSlice.Len()
+
 	meta := appDto.MetaDTO{
-		Count:      len(data),
+		Count:      count,
 		Page:       page,
 		TotalPages: int(math.Ceil(float64(totalCount) / float64(limit))),
 		TotalCount: totalCount,
@@ -51,7 +55,7 @@ func PaginateError(errors []appDto.CustomErrorDTO) PaginateErrorResponse {
 		Count:      len(errors),
 		Page:       1,
 		TotalPages: 1,
-		TotalCount: len(errors),
+		TotalCount: int64(len(errors)),
 		Limit:      1,
 	}
 

--- a/src/manager/controller/controller.go
+++ b/src/manager/controller/controller.go
@@ -3,6 +3,7 @@ package managerController
 import (
 	"errors"
 
+	appDto "github.com/chronicler-org/core/src/app/dto"
 	appUtil "github.com/chronicler-org/core/src/app/utils"
 	managerDTO "github.com/chronicler-org/core/src/manager/dto"
 	managerService "github.com/chronicler-org/core/src/manager/service"
@@ -19,12 +20,13 @@ func InitManagerController(s *managerService.ManagerService) *ManagerController 
 		service: s,
 	}
 }
-func (controller *ManagerController) HandleFindAll(c *fiber.Ctx) error {
-	managers, err := controller.service.FindAll()
-	if err != nil {
-		return c.SendStatus(fiber.StatusInternalServerError)
-	}
-	return c.Status(fiber.StatusOK).JSON(managers)
+func (controller *ManagerController) HandleFindAll(c *fiber.Ctx) (appUtil.PaginateResponse, error) {
+	var paginationDto appDto.PaginationDTO
+	c.QueryParser(&paginationDto)
+
+	totalCount, managers, err := controller.service.FindAll(paginationDto)
+
+	return appUtil.Paginate(managers, totalCount, paginationDto.GetPage(), paginationDto.GetLimit()), err
 }
 
 func (controller *ManagerController) HandleFindByID(c *fiber.Ctx) (appUtil.PaginateResponse, error) {

--- a/src/manager/repository/repository.go
+++ b/src/manager/repository/repository.go
@@ -29,10 +29,17 @@ func (repository *ManagerRepository) Update(updatedManager managerModel.Manager)
 	return repository.db.Save(updatedManager).Error
 }
 
-func (repository *ManagerRepository) FindAll() ([]managerModel.Manager, error) {
+func (repository *ManagerRepository) FindAll(limit, page int) ([]managerModel.Manager, error) {
 	var managers []managerModel.Manager
-	err := repository.db.Find(&managers).Error
+	offset := (page - 1) * limit
+	err := repository.db.Limit(limit).Offset(offset).Find(&managers).Error
 	return managers, err
+}
+
+func (repository *ManagerRepository) Count() (int64, error) {
+	var count int64
+	err := repository.db.Model(&managerModel.Manager{}).Count(&count).Error
+	return count, err
 }
 
 func (repository *ManagerRepository) Delete(id string) error {

--- a/src/manager/router/router.go
+++ b/src/manager/router/router.go
@@ -1,6 +1,7 @@
 package managerRouter
 
 import (
+	appDto "github.com/chronicler-org/core/src/app/dto"
 	"github.com/chronicler-org/core/src/app/middleware"
 	appUtil "github.com/chronicler-org/core/src/app/utils"
 	managerController "github.com/chronicler-org/core/src/manager/controller"
@@ -19,11 +20,9 @@ func InitManagerRouter(router *fiber.App, db *gorm.DB) {
 	service := managerService.InitManagerService(repository, validate)
 	controller := managerController.InitManagerController(service)
 
-	router.Get("/manager", controller.HandleFindAll)
+	router.Get("/manager", middleware.Validate(nil, &appDto.PaginationDTO{}), appUtil.Controller(controller.HandleFindAll))
 	router.Get("/manager/:id", appUtil.Controller(controller.HandleFindByID))
-
-	router.Post("/manager", middleware.Validate(&managerDTO.CreateManagerDTO{}), appUtil.Controller(controller.HandleCreateManager))
-
+	router.Post("/manager", middleware.Validate(&managerDTO.CreateManagerDTO{}, nil), appUtil.Controller(controller.HandleCreateManager))
 	router.Patch("/manager/:id", controller.HandleUpdateManager)
 	router.Delete("/manager/:id", controller.HandleDeleteManager)
 

--- a/src/manager/service/service.go
+++ b/src/manager/service/service.go
@@ -3,6 +3,7 @@ package managerService
 import (
 	"time"
 
+	appDto "github.com/chronicler-org/core/src/app/dto"
 	managerDTO "github.com/chronicler-org/core/src/manager/dto"
 	managerModel "github.com/chronicler-org/core/src/manager/model"
 	managerRepository "github.com/chronicler-org/core/src/manager/repository"
@@ -94,8 +95,14 @@ func (service *ManagerService) Update(id string, dto managerDTO.UpdateManagerDTO
 	return updatedManager, err
 }
 
-func (service *ManagerService) FindAll() ([]managerModel.Manager, error) {
-	return service.repository.FindAll()
+func (service *ManagerService) FindAll(dto appDto.PaginationDTO) (int64, []managerModel.Manager, error) {
+	totalCount, err := service.repository.Count()
+	if err != nil {
+		return 0, nil, err
+	}
+
+	managers, err := service.repository.FindAll(dto.GetLimit(), dto.GetPage())
+	return totalCount, managers, err
 }
 
 func (service *ManagerService) Delete(id string) error {


### PR DESCRIPTION
Esta merge request adiciona suporte para paginação no endpoint /manager, permitindo que os usuários controlem o número de resultados retornados e a página a ser exibida. A paginação é uma técnica comum usada para lidar com grandes conjuntos de dados, dividindo-os em páginas menores e permitindo que os usuários naveguem facilmente entre elas.

Detalhes:

- Foram adicionados os campos limit e page ao DTO PaginationDTO.
- O campo limit define o número máximo de registros a serem retornados em uma única página. Ele é validado para garantir que esteja entre 1 e 100, para evitar sobrecarga do sistema.
- O campo page indica a página desejada do conjunto de resultados. Ele é validado para garantir que seja maior ou igual a 1, para evitar páginas inválidas.